### PR TITLE
ios - memory cloud leak.

### DIFF
--- a/src/ios/BlinkUpPlugin.h
+++ b/src/ios/BlinkUpPlugin.h
@@ -18,6 +18,7 @@
 #import <Cordova/CDV.h>
 
 @class BUBasicController;
+@class BUFlashController;
 
 @interface BlinkUpPlugin : CDVPlugin
 
@@ -30,10 +31,11 @@
 - (void)clearBlinkUpData:(CDVInvokedUrlCommand *)command;
 
 // instance variables
-@property BUBasicController *blinkUpController;
-@property NSString *apiKey;
-@property NSString *callbackId;
-@property NSString *developerPlanId;
+@property (strong) BUBasicController *blinkUpController;
+@property (strong) BUFlashController *flashController;
+@property (strong) NSString *apiKey;
+@property (strong) NSString *callbackId;
+@property (strong) NSString *developerPlanId;
 @property NSInteger timeoutMs;
 @property BOOL generatePlanId;
 

--- a/src/ios/BlinkUpPluginResult.m
+++ b/src/ios/BlinkUpPluginResult.m
@@ -76,12 +76,12 @@ NSString * const DEVICE_INFO_KEY = @"deviceInfo";
 
     // set our state (never null)
     [resultsDict setObject:[self stateToJsonKey] forKey:STATE_KEY];
-    
+
     // add error if necessary
     if (_state == Error) {
         [resultsDict setObject:[self generateErrorDict] forKey:ERROR_KEY];
     }
-    
+
     // completed without error
     else {
         [resultsDict setObject:[@(_statusCode) stringValue] forKey:STATUS_CODE_KEY];
@@ -98,7 +98,7 @@ NSString * const DEVICE_INFO_KEY = @"deviceInfo";
  ********************************************/
 - (NSMutableDictionary *) generateErrorDict {
     NSMutableDictionary *errorDict = [[NSMutableDictionary alloc] init];
-    
+
     if (_errorType == BlinkUpSDKError) {
         [errorDict setObject:@"blinkup" forKey:ERROR_TYPE_KEY];
         [errorDict setObject:_errorMsg forKey:ERROR_MSG_KEY];
@@ -130,10 +130,10 @@ NSString * const DEVICE_INFO_KEY = @"deviceInfo";
  * Helper: takes dict and returns JSON string
  ********************************************/
 - (NSString *) toJsonString:(NSMutableDictionary *)resultsDict {
-    
+
     NSError *jsonError;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:resultsDict options:NSJSONWritingPrettyPrinted error:&jsonError];
-    
+
     if (jsonError != nil) {
         NSLog(@"Error converting to JSON. %@", jsonError.localizedDescription);
         return @"";


### PR DESCRIPTION
Cause: Recycling controllers is causing memory leaks of elements that we don't control in the plugin.
Fix: Re-using Blinkup controller instance. It is tied 1:1 with the lifecycle of the webapplication in this case.