### PR TITLE
Inject after plugin and platform add + prevent multiple injections

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,9 +64,11 @@
     <platform name="android">
         <!-- Application specific permission injections -->
         <hook type="after_platform_add" src="scripts/android/manifest_permission_inject.js" />
+        <hook type="after_plugin_add" src="scripts/android/manifest_permission_inject.js" />
         
         <!-- Injections for blinkup -->
         <hook type="after_platform_add" src="scripts/android/blinkup/main_activity_inject.js" />
+        <hook type="after_plugin_add" src="scripts/android/blinkup/main_activity_inject.js" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="cordova-blinkup-plugin">

--- a/scripts/android/blinkup/main_activity_inject.js
+++ b/scripts/android/blinkup/main_activity_inject.js
@@ -1,14 +1,15 @@
 module.exports = function(ctx) {
   'use strict';
   // make sure android platform is part of build
-  if (ctx.opts.platforms.indexOf('android') < 0) {
+  if (ctx.opts.platforms && ctx.opts.platforms.indexOf('android') < 0) {
     return;
   }
   var fs = ctx.requireCordovaModule('fs');
   var path = ctx.requireCordovaModule('path');
   var deferral = ctx.requireCordovaModule('q').defer();
   var matchString1 = 'import org.apache.cordova.*;';
-  var replaceString1 = 'import org.apache.cordova.*;\nimport android.content.Intent;\nimport com.electricimp.blinkup.BlinkupController;'; // jshint ignore:line
+  var replaceString1 =
+    'import org.apache.cordova.*;\nimport android.content.Intent;\nimport com.electricimp.blinkup.BlinkupController;'; // jshint ignore:line
 
   var matchString2 = 'public class MainActivity extends CordovaActivity\n{';
   var replaceString2 = fs.readFileSync(path.join(__dirname, 'main_activity_inject.txt'), 'utf-8');
@@ -25,6 +26,12 @@ module.exports = function(ctx) {
       if (err) {
         return deferral.reject('Read file operation failed');
       }
+
+      if (data.indexOf(replaceString1) !== -1) {
+        console.log('CordovaBlinkUp Plugin: MainActivity already injected.');
+        return deferral.resolve();
+      }
+
       var result = data.replace(matchString1, replaceString1);
       result = result.replace(matchString2, replaceString2);
 
@@ -34,7 +41,7 @@ module.exports = function(ctx) {
           if (err) {
             return deferral.reject('Write file operation failed');
           }
-          console.log('MAIN ACTIVITY INJECTIONS ADDED SUCCESSFULLY');
+          console.log('CordovaBlinkUp Plugin: MainActivity injection successfullly');
           deferral.resolve();
         });
     });

--- a/scripts/android/manifest_permission_inject.js
+++ b/scripts/android/manifest_permission_inject.js
@@ -1,29 +1,35 @@
 module.exports = function(ctx) {
   'use strict';
   // make sure android platform is part of build
-  if (ctx.opts.platforms.indexOf('android') < 0) {
+  if (ctx.opts.platforms && ctx.opts.platforms.indexOf('android') < 0) {
     return;
   }
   var fs = ctx.requireCordovaModule('fs');
   var path = ctx.requireCordovaModule('path');
   var deferral = ctx.requireCordovaModule('q').defer();
-  var jsonFile = JSON.parse(fs.readFileSync(path.join(__dirname,'manifest_permission_inject.json')));
+  var jsonFile = JSON.parse(fs.readFileSync(path.join(__dirname, 'manifest_permission_inject.json')));
   var injectPermissions = jsonFile.basePermission.concat(jsonFile.addPermissions);
 
   fs.readFile(path.join(ctx.opts.projectRoot,
-  'platforms/android/AndroidManifest.xml'), 'utf-8', function (err,data) {
+    'platforms/android/AndroidManifest.xml'), 'utf-8', function(err, data) {
     if (err) {
       return deferral.reject('Read file operation failed');
     }
-    var result = data.replace(jsonFile.basePermission,injectPermissions.join('\n\t\t'));
+
+    if (data.indexOf(jsonFile.addPermissions[0]) !== -1) {
+      console.log('CordovaBlinkUp Plugin: AndroidManifest already injected');
+      return deferral.resolve();
+    }
+
+    var result = data.replace(jsonFile.basePermission, injectPermissions.join('\n\t\t'));
 
     fs.writeFile(path.join(ctx.opts.projectRoot,
-    'platforms/android/AndroidManifest.xml'), result, 'utf-8', function (err) {
-       if (err) {
-         return deferral.reject('Write file operation failed');
-       }
-       console.log('ANDROID MANIFEST INJECTIONS ADDED SUCCESSFULLY');
-       deferral.resolve();
+      'platforms/android/AndroidManifest.xml'), result, 'utf-8', function(err) {
+      if (err) {
+        return deferral.reject('Write file operation failed');
+      }
+      console.log('CordovaBlinkUp Plugin: AndroidManifest injected successfullly');
+      deferral.resolve();
     });
   });
   return deferral.promise;


### PR DESCRIPTION
Inject MainActivity and AndroidManifest after platform add and after plugin add.

Prevent multiple MainActivity and AndroidManifest injection.

Avoid crash when plugin is added when no platforms are defined