### PR TITLE
Updated Plugin API - IOS + Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,34 +18,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="com.macadamian.blinkup"
-        version="1.0.0">
-    
+        version="1.1.0">
+
     <name>cordova-blinkup-plugin</name>
     <description>
         This plugin allows you to integrate the native BlinkUp process for setting up an Electric Imp device directly into your Cordova / PhoneGap project.
-        
+
         The Plan ID, Device ID, Agent URL, Verfication Date, and status of the operation are all passed back as JSON to the Cordova application, along with a status or error code (see ReadMe.md for JSON format and status code definitions).
     </description>
-    
+
     <info>
         There are several required steps to perform before your application will run. Please see ReadMe.md for information on installation and usage.
 
         If you previously had the plugin installed and are simply updating it, then you do not need to repeat the installation steps.
     </info>
-    
+
     <license>
         Licensed under the Apache License, Version 2.0 (the "License");
         you may not use this file except in compliance with the License.
         You may obtain a copy of the License at
-        
+
         http://www.apache.org/licenses/LICENSE-2.0
-        
+
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,
         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
         See the License for the specific language governing permissions and
         limitations under the License.
-        
+
         Created by Stuart Douglas (sdouglas@macadamian.com) on June 11, 2015.
         Copyright (c) 2015 Macadamian. All rights reserved.
     </license>
@@ -65,7 +65,7 @@
         <!-- Application specific permission injections -->
         <hook type="after_platform_add" src="scripts/android/manifest_permission_inject.js" />
         <hook type="after_plugin_add" src="scripts/android/manifest_permission_inject.js" />
-        
+
         <!-- Injections for blinkup -->
         <hook type="after_platform_add" src="scripts/android/blinkup/main_activity_inject.js" />
         <hook type="after_plugin_add" src="scripts/android/blinkup/main_activity_inject.js" />
@@ -123,5 +123,5 @@
         <header-file src="src/ios/BUDeviceInfo+JSON.h" />
         <source-file src="src/ios/BUDeviceInfo+JSON.m" />
     </platform>
-    
+
 </plugin>

--- a/src/ios/BlinkUpPlugin.h
+++ b/src/ios/BlinkUpPlugin.h
@@ -16,6 +16,7 @@
  */
 
 #import <Cordova/CDV.h>
+#import <AvailabilityMacros.h>
 
 @class BUBasicController;
 @class BUFlashController;
@@ -26,7 +27,7 @@
 // Shows BlinkUp UI for user to enter wifi details and
 // perform the screen flash process to connect to an Imp
 //------------------------------------------------------
-- (void)invokeBlinkUp:(CDVInvokedUrlCommand *)command;
+- (void)startBlinkUp:(CDVInvokedUrlCommand *)command;
 - (void)abortBlinkUp:(CDVInvokedUrlCommand *)command;
 - (void)clearBlinkUpData:(CDVInvokedUrlCommand *)command;
 
@@ -37,6 +38,12 @@
 @property (strong) NSString *callbackId;
 @property (strong) NSString *developerPlanId;
 @property NSInteger timeoutMs;
-@property BOOL generatePlanId;
+@property BOOL isInDevelopment;
+
+//------------------------------------------------------
+// Deprecated Calls.
+//------------------------------------------------------
+- (void)invokeBlinkUp:(CDVInvokedUrlCommand *)command DEPRECATED_MSG_ATTRIBUTE("Use startBlinkUp: method instead.");
+@property BOOL generatePlanId DEPRECATED_ATTRIBUTE;
 
 @end

--- a/www/blinkup.js
+++ b/www/blinkup.js
@@ -18,7 +18,26 @@
 /*global cordova, module*/
 
 module.exports = {
-    //apiKey: string, developerPlanId: string, timeoutMs: int, generateNewPlanId: bool 
+    /** startBlinkUp - starts the blinkup process
+    * @param {apiKey}: your blinkup api key
+    * @param {developerPlanId}: your development plan Id. Will be disregarded when {isInDevelopment} is set to false
+    * @param {isInDevelopment}: true if you are connecting to development devices. when you are moving to production devices, this must be set to TRUE.
+    * @param {timeoutMS}: Amount of second before the application times out. Default & Maximum value is 60000.
+    */
+    startBlinkUp: function (apiKey, developerPlanId, isInDevelopment, timeoutMs, successCallback, errorCallback) {
+        cordova.exec(successCallback, errorCallback, "cordova-blinkup-plugin", "startBlinkUp", [apiKey, developerPlanId, isInDevelopment, timeoutMs]);
+    },
+    /** startBlinkUp - starts the blinkup process
+    * @param {apiKey}: your blinkup api key
+    * @param {developerPlanId}: your development plan Id. Will be disregarded when {isInDevelopment} is set to false
+    * @param {isInDevelopment}: true if you are connecting to development devices. when you are moving to production devices, this must be set to TRUE.
+    */
+    startBlinkUp: function (apiKey, developerPlanId, isInDevelopment, successCallback, errorCallback) {
+        cordova.exec(successCallback, errorCallback, "cordova-blinkup-plugin", "startBlinkUp", [apiKey, developerPlanId, isInDevelopment, 60000]);
+    },
+    /**
+    * @deprecated Since version 1.1. Will be deleted in version 2.0. Use startBlinkUp instead.
+    */
     invokeBlinkUp: function (apiKey, developerPlanId, timeoutMs, generateNewPlanId, successCallback, errorCallback) {
         cordova.exec(successCallback, errorCallback, "cordova-blinkup-plugin", "invokeBlinkUp", [apiKey, developerPlanId, timeoutMs, generateNewPlanId]);
     },


### PR DESCRIPTION
Now version 1.1!

Passed from Javascript through a new api startBlinkUp so as to not break the previous api call (invokeBlinkUp).
IsInDevelopment: no longer a pre-processor call. Required argument for startBlinkUp.
InvokeBlinkUp is now deprecated and will be removed in a future release, please use startBlinkUp from now on.

Tested with Cordova-BlinkUpSample application.
- invoke API tested that it behave identically to before.
- startBlinkup tested with isInDevelopment set to true false.
- validation without a developer plan id.