### PR TITLE
Blinkup Timeout Causing Issues (iOS).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-blinkup-plugin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "This plugin allows you to integrate the native BlinkUp process for setting up an Electric Imp device directly into your Cordova / PhoneGap project",
   "cordova": {
     "id": "com.macadamian.blinkup",

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="com.macadamian.blinkup"
-        version="1.1.2">
+        version="1.1.3">
 
     <name>cordova-blinkup-plugin</name>
     <description>

--- a/src/ios/BlinkUpPlugin.m
+++ b/src/ios/BlinkUpPlugin.m
@@ -184,12 +184,6 @@ typedef NS_ENUM(NSInteger, InvokeBlinkupArguments) {
         [_blinkUpController presentInterfaceAnimated:YES
             resignActive: ^(BOOL willRespond, BOOL userDidCancel, NSError *error) {
                 [self blinkUpDidComplete:willRespond userDidCancel:userDidCancel error:error clearedCache:false];
-
-                // device poller is nil until this block completes, so set its timeout 0.5 seconds from now
-                // this is a HACK, need to solve before release
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-                    _blinkUpController.devicePoller.pollTimeout = (_timeoutMs / 1000.0);
-                });
             }
             devicePollingDidComplete: ^(BUDeviceInfo *deviceInfo, BOOL timedOut, NSError *error) {
                 [self deviceRequestDidCompleteWithDeviceInfo:deviceInfo timedOut:timedOut error:error];


### PR DESCRIPTION
Cause: Device Poller isn't initialized until the blinkup process is done, and setting the timeout at that point causes issues for subsequent blinkups.
Device Poller is likely intented for custom blinkup views, otherwise it is created by the controller itself. It appears that changing its properties while it is in use is affecting blinkupu stability on ios.

Fix: Removing the logic which sets timeout during blinkup. Note: we will be using the default timeout value for the time being in iOS.
Tested:
- Blinkup / Clear / Blinkup
- Blinkup / Blinkup / Blinkup

Results:
- Not 100% but alot closer, alot fewer timeouts than we were used to.