### PR TITLE
Upgraded plugin to use Android Blinkup SDK 6.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DEBUG=1
 Android
 --------------
 **STEP 1**<br>
-Copy the `blinkup.aar` file from the SDK package given to you by Electric Imp to `/path/to/project/platforms/android/libs`.
+Copy the entire `repo` folder from the SDK 6.3.0 package given to you by Electric Imp to `/path/to/project/platforms/android/`.
 
 NOTES:
 
@@ -60,7 +60,7 @@ There are three calls from the plugin exposed to the javascript through the `bli
 
 All calls take success and failure callbacks as arguments. See the "Callbacks" section below for more information.
 
-**startBlinkUp(apiKey, planId, timeoutMs, generateNewPlanId, success, failure)**<br>
+**startBlinkUp(apiKey, developmentPlanId, isInDevelopment, timeoutMs, success, failure)**<br>
 Presents the native BlinkUp interface, where user can input wifi info and connect to the Imp.<br>
 `apiKey` *string*: you must enter your apiKey or the plugin won't function.<br>
 `developmentPlanId` *string, default=""*: **IMPORTANT** - you must read "[Testing the Plugin](#testing-the-plugin)" before setting this value. Failure to do so can prevent users from connecting to wifi.<br>
@@ -179,12 +179,6 @@ Troubleshooting
 - `BlinkUp.framework` is not in the project's "Link binary with libraries" build phase
 - "Framework Search Paths" in the project's build settings does not include `$(PROJECT_DIR)/BlinkUp.embeddedframework`
 - If the three conditions above are correct and it still does not work, try removing the BlinkUp.framework from "Link binary with librairies" and re-adding it. This is a bug in Xcode.
-
-###Android
-**Project with path "blinkup_sdk" could not be found**
-- The `blinkup_sdk` folder is not in `path/to/project/platforms/android/`
-- The `build.js` file was not updated as outlined in [installation](#android)
-- `cordova build android` was not run after updating the `build.js` file
 
 ###BlinkUp
 **BlinkUp process times out**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-blinkup-plugin",
-  "version": "1.1.5",
+  "version": "2.0.0",
   "description": "This plugin allows you to integrate the native BlinkUp process for setting up an Electric Imp device directly into your Cordova / PhoneGap project",
   "cordova": {
     "id": "com.macadamian.blinkup",

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="com.macadamian.blinkup"
-        version="1.1.5">
+        version="2.0.0">
 
     <name>cordova-blinkup-plugin</name>
     <description>
@@ -83,12 +83,6 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <activity android:name="com.macadamian.blinkup.ClearCompleteActivity" android:configChanges="orientation" android:screenOrientation="portrait" />
             <activity android:name="com.macadamian.blinkup.BlinkUpCompleteActivity" android:configChanges="orientation" android:screenOrientation="portrait" />
-            <activity android:name="com.electricimp.blinkup.WifiSelectActivity" android:label="BlinkUp" android:configChanges="orientation" android:screenOrientation="portrait" />
-            <activity android:name="com.electricimp.blinkup.BlinkupGLActivity" android:label="BlinkUp" android:configChanges="orientation" android:screenOrientation="portrait" />
-            <activity android:name="com.electricimp.blinkup.WifiActivity" android:label="BlinkUp" android:configChanges="orientation" android:screenOrientation="portrait" />
-            <activity android:name="com.electricimp.blinkup.WPSActivity" android:label="BlinkUp" android:configChanges="orientation" android:screenOrientation="portrait" />
-            <activity android:name="com.electricimp.blinkup.ClearWifiActivity" android:label="BlinkUp" android:configChanges="orientation" android:screenOrientation="portrait" />
-            <activity android:name="com.electricimp.blinkup.InterstitialActivity" android:label="BlinkUp" android:configChanges="orientation" android:screenOrientation="portrait" />
         </config-file>
 
         <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,3 +1,9 @@
-repositories { flatDir { dirs 'libs' } }
+repositories {
+    maven {
+        url "repo"
+    }
+}
 
-dependencies { compile(name:'blinkup', ext:'aar') }
+dependencies {
+    compile 'com.electricimp:blinkup:6.3.0'
+}

--- a/src/ios/BlinkUpPlugin.h
+++ b/src/ios/BlinkUpPlugin.h
@@ -40,10 +40,4 @@
 @property NSInteger timeoutMs;
 @property BOOL isInDevelopment;
 
-//------------------------------------------------------
-// Deprecated Calls.
-//------------------------------------------------------
-- (void)invokeBlinkUp:(CDVInvokedUrlCommand *)command DEPRECATED_MSG_ATTRIBUTE("Use startBlinkUp: method instead.");
-@property BOOL generatePlanId DEPRECATED_ATTRIBUTE;
-
 @end

--- a/src/ios/BlinkUpPlugin.m
+++ b/src/ios/BlinkUpPlugin.m
@@ -44,13 +44,6 @@ typedef NS_ENUM(NSInteger, StartBlinkupArguments) {
     StartBlinkUpArgumentTimeOut,
 };
 
-typedef NS_ENUM(NSInteger, InvokeBlinkupArguments) {
-    BlinkUpArgumentApiKey = 0,
-    BlinkUpArgumentDeveloperPlanId,
-    BlinkUpArgumentTimeOut,
-    BlinkUpArgumentGeneratePlanId
-};
-
 @implementation BlinkUpPlugin
 
 /*********************************************************
@@ -72,30 +65,6 @@ typedef NS_ENUM(NSInteger, InvokeBlinkupArguments) {
         }
 
         NSLog(@"startBlinkUp. isInDevelopment? %d, timeoutMs? %ld", _isInDevelopment, (long)_timeoutMs);
-
-        [self navigateToBlinkUpView];
-    }];
-}
-
-/*********************************************************
- * Parses arguments from javascript and displays BlinkUp
- ********************************************************/
-- (void)invokeBlinkUp:(CDVInvokedUrlCommand*)command {
-    NSLog(@"invokeBlinkUp Started.");
-
-    _callbackId = command.callbackId;
-
-    [self.commandDelegate runInBackground:^{
-        _apiKey = [command.arguments objectAtIndex:BlinkUpArgumentApiKey];
-        _developerPlanId = [command.arguments objectAtIndex:BlinkUpArgumentDeveloperPlanId];
-        _timeoutMs = [[command.arguments objectAtIndex:BlinkUpArgumentTimeOut] integerValue];
-        _generatePlanId = [[command.arguments objectAtIndex:BlinkUpArgumentGeneratePlanId] boolValue];
-
-        if ([self sendErrorToCallbackIfArgumentsInvalid]) {
-            return;
-        }
-
-        NSLog(@"invokeBlinkUp with timeoutMS: %ld", (long)_timeoutMs);
 
         [self navigateToBlinkUpView];
     }];
@@ -167,7 +136,6 @@ typedef NS_ENUM(NSInteger, InvokeBlinkupArguments) {
 
 #ifdef DEBUG
     planId = _developerPlanId;
-    _generatePlanId = false;
 #endif
 
     if (planId == _developerPlanId) {
@@ -175,7 +143,7 @@ typedef NS_ENUM(NSInteger, InvokeBlinkupArguments) {
     }
 
     if (_blinkUpController == nil) {
-        _blinkUpController = (_generatePlanId || planId == nil)
+        _blinkUpController = (planId == nil)
                                 ? [[BUBasicController alloc] initWithApiKey:_apiKey]
                                 : [[BUBasicController alloc] initWithApiKey:_apiKey planId:planId];
     }

--- a/www/blinkup.js
+++ b/www/blinkup.js
@@ -27,12 +27,6 @@ module.exports = {
     startBlinkUp: function (apiKey, developerPlanId, isInDevelopment, timeoutMs, successCallback, errorCallback) {
         cordova.exec(successCallback, errorCallback, "cordova-blinkup-plugin", "startBlinkUp", [apiKey, developerPlanId, isInDevelopment, timeoutMs]);
     },
-    /**
-    * @deprecated Since version 1.1. Will be deleted in version 2.0. Use startBlinkUp instead.
-    */
-    invokeBlinkUp: function (apiKey, developerPlanId, timeoutMs, generateNewPlanId, successCallback, errorCallback) {
-        cordova.exec(successCallback, errorCallback, "cordova-blinkup-plugin", "invokeBlinkUp", [apiKey, developerPlanId, timeoutMs, generateNewPlanId]);
-    },
     abortBlinkUp: function (successCallback, errorCallback) {
         cordova.exec(successCallback, errorCallback, "cordova-blinkup-plugin", "abortBlinkUp", []);
     },


### PR DESCRIPTION
Version 2.0.0

- upgraded plugin to use electric Imp's Android Blinkup SDK 6.3.0
- removed deprecated API call invokeBlinkUp(), use startBlinkUp() instead
- updated version number to 2.0.0
- note: for android projects the minSdkVersion should be set to at least 19 (since Android Blinkup SDK 6.2.0)

Test:
- tested in production app